### PR TITLE
fix for CursorQuery class causing MRO error sometimes

### DIFF
--- a/db/utils.py
+++ b/db/utils.py
@@ -26,10 +26,11 @@ def get_cursor(queryset):
 def set_cursor(queryset, start=None, end=None):
     queryset = queryset.all()
 
-    class CursorQuery(CursorQueryMixin, queryset.query.__class__):
-        pass
+    if CursorQueryMixin not in queryset.query.__class__.__bases__:
+        class CursorQuery(CursorQueryMixin, queryset.query.__class__):
+            pass
+        queryset.query = queryset.query.clone(klass=CursorQuery)
 
-    queryset.query = queryset.query.clone(klass=CursorQuery)
     if start is not None:
         start = Cursor.from_websafe_string(start)
     queryset.query._gae_start_cursor = start


### PR DESCRIPTION
fix rare issue where you get 'Cannot create a consistent method resolution order (MRO) for bases CursorQueryMixin, CursorQuery' i.e. it's trying to mixin the mixin twice

I was getting this when working with sliced values_list querysets

I don't have a test case and I can't rule out it wasn't a result of interaction with own custom code, however checking the bases before mixing seems prudent anyway
