### PR TITLE
Patch boot.py for SDK 1.6.4

### DIFF
--- a/boot.py
+++ b/boot.py
@@ -63,6 +63,8 @@ def setup_env():
             else:
                 if name == 'webapp2':
                     extra_paths.append(root)
+                elif name == 'webob_0_9':
+                    extra_paths.append(root)
         sys.path = extra_paths + sys.path
         from google.appengine.api import apiproxy_stub_map
 


### PR DESCRIPTION
Running "python manage.py  runserver" (or any other commands for that matter) fails on SDK 1.6.4, this patch fixes it, at least for me, running on python 2.5.  I'm not sure if it fixes python 2.7 runtime issues.
