### PR TITLE
Reissue pull request #25

### DIFF
--- a/boot.py
+++ b/boot.py
@@ -157,6 +157,13 @@ def setup_project():
             logging.warn('Could not patch modules whitelist. '
                          'The compiler and parser modules will not work and '
                          'SSL support is disabled.')
+        # In SDK 1.6.4, the datastore doesn't save automatically on exit.
+        # Register a handler to make sure we save.  This is important on 
+        # manage.py commands other than 'runserver'.  Note that with runserver,
+        # the datastore is flushed twice.  This should be acceptable.
+        import atexit
+        if hasattr(dev_appserver, 'TearDownStubs'):
+            atexit.register(dev_appserver.TearDownStubs)
     elif not on_production_server:
         try:
             # Restore the real subprocess module
@@ -189,10 +196,3 @@ def setup_project():
                 sys.path.remove(path)
         sys.path = extra_paths + sys.path
 
-    # In SDK 1.6.4, the datastore doesn't save automatically on exit.
-    # Register a handler to make sure we save.  This is important on 
-    # manage.py commands other than 'runserver'.  Note that with runserver,
-    # the datastore is flushed twice.  This should be acceptable.
-    import atexit
-    if hasattr(dev_appserver, 'TearDownStubs'):
-        atexit.register(dev_appserver.TearDownStubs)


### PR DESCRIPTION
This is a clean version of pull request #25.

This was originally required because App Engine SDK 1.6.4 would not save the datastore to disk when using "manage.py shell".  ("manage.py runserver" would save when killed with Ctrl-C)

In SDK 1.6.5 and 1.6.6, the SDK will save the datastore to disk using "manage.py shell", but not when killing "manage.py runserver" with Ctrl-C.  Go figure.

The original patch in request #25 fixes the new problem too. 
