### PR TITLE
Use inline literal syntax to avoid turning hyphens to dashes

### DIFF
--- a/docs/services.rst
+++ b/docs/services.rst
@@ -7,7 +7,7 @@ You can (and should) use Django's mail API instead of App Engine's mail API. The
 
 Emails will be deferred to the task queue specified in the EMAIL_QUEUE_NAME setting. If you run the dev appserver with --disable_task_running then you'll see the tasks being deposited in the queue. You can manually execute those tasks from the GUI at /_ah/admin/tasks.
 
-If you execute the dev appserver with the options "--smtp_host=localhost --smtp_port=1025" and run the dev smtp server in a terminal with 'python -m smtpd -n -c DebuggingServer localhost:1025' then you'll see emails delivered to that terminal for debug.
+If you execute the dev appserver with the options ``--smtp_host=localhost --smtp_port=1025`` and run the dev smtp server in a terminal with ``python -m smtpd -n -c DebuggingServer localhost:1025`` then you'll see emails delivered to that terminal for debug.
 
 Cache API
 ---------------------------------------------
@@ -18,7 +18,7 @@ Sessions
 You can use Django's session API in your code. The ``cached_db`` session backend is already enabled in the default settings.
 
 Authentication
----------------------------------------------
+-----------------------------------------------
 You can (and probably should) use ``django.contrib.auth`` directly in your code. We don't recommend to use App Engine's Google Accounts API. This will lock you into App Engine unnecessarily. Use Django's auth API, instead. If you want to support Google Accounts you can do so via OpenID. Django has several apps which provide OpenID support via Django's auth API. This also allows you to support Yahoo and other login options in the future and you're independent of App Engine. Take a look at `Google OpenID Sample Store`_ to see an example of what OpenID login for Google Accounts looks like.
 
 Note that username uniqueness is only checked at the form level (and by Django's model validation API if you explicitly use that). Since App Engine doesn't support uniqueness constraints at the DB level it's possible, though very unlikely, that two users register the same username at exactly the same time. Your registration confirmation/activation mechanism (i.e., user receives mail to activate his account) must handle such cases correctly. For example, the activation model could store the username as its primary key, so you can be sure that only one of the created users is activated.


### PR DESCRIPTION
This commit changes some quoted strings to `string` from "string".

The rationale is that within "string" context, two hyphens become an em dash. Within `string` context, they stay hyphens. This is important for commands that could be copy-pasted, or that help people see what commands they should type into their own terminals.

This work is my own, and I grant permission to distribute this change under the terms of the CC Zero (i.e., I waive all copyright rights) or under the terms of Apache License 2.0; any redistributor is permitted to choose whichever (or both) terms to use.
