### PR TITLE
Lazy instatiation of Testbed to prevent SSL warning

### DIFF
--- a/djangoappengine/db/stubs.py
+++ b/djangoappengine/db/stubs.py
@@ -3,8 +3,6 @@ import os
 import time
 from urllib2 import HTTPError, URLError
 
-from google.appengine.ext.testbed import Testbed
-
 from ..boot import PROJECT_DIR
 from ..utils import appid, have_appserver
 
@@ -29,7 +27,7 @@ def rpc_server_factory(*args, ** kwargs):
 class StubManager(object):
 
     def __init__(self):
-        self.testbed = Testbed()
+        self.testbed = None
         self.active_stubs = None
         self.pre_test_stubs = None
 
@@ -52,6 +50,10 @@ class StubManager(object):
         if high_replication:
             from google.appengine.datastore import datastore_stub_util
             datastore_opts['consistency_policy'] = datastore_stub_util.PseudoRandomHRConsistencyPolicy(probability=1)
+
+        if self.testbed is None:
+            from google.appengine.ext.testbed import Testbed
+            self.testbed = Testbed()
 
         self.testbed.activate()
         self.pre_test_stubs = self.active_stubs


### PR DESCRIPTION
Under Python 2.7, the production server prints warnings on every
request about a missing "urlfetch_cacerts.txt" file. The easiest
fix is lazy instantiation of the Testbed() object, as discussed at:
https://code.google.com/p/googleappengine/issues/detail?id=5578
