### PR TITLE
DatabaseOperations(self) TypeError: __init__() takes exactly 1 argument ...

### DIFF
--- a/djangoappengine/db/base.py
+++ b/djangoappengine/db/base.py
@@ -287,7 +287,7 @@ class DatabaseWrapper(NonrelDatabaseWrapper):
     def __init__(self, *args, **kwds):
         super(DatabaseWrapper, self).__init__(*args, **kwds)
         self.features = DatabaseFeatures(self)
-        self.ops = DatabaseOperations(self)
+        self.ops = DatabaseOperations()
         self.client = DatabaseClient(self)
         self.creation = DatabaseCreation(self)
         self.validation = DatabaseValidation(self)


### PR DESCRIPTION
...(2 given)

I tried to start a project using this tutorial:
http://www.allbuttonspressed.com/projects/djangoappengine

Got this error when running `./manage.py runserver`:

```$ ./manage.py runserver
Traceback (most recent call last):
  File "./manage.py", line 11, in <module>
    execute_manager(settings)
  File "/home/tony/work/qmag/django-testapp/django/core/management/**init**.py", line 438, in execute_manager
    utility.execute()
  File "/home/tony/work/qmag/django-testapp/django/core/management/**init**.py", line 379, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/home/tony/work/qmag/django-testapp/django/core/management/**init**.py", line 261, in fetch_command
    klass = load_command_class(app_name, subcommand)
  File "/home/tony/work/qmag/django-testapp/django/core/management/**init**.py", line 67, in load_command_class
    module = import_module('%s.management.commands.%s' % (app_name, name))
  File "/home/tony/work/qmag/django-testapp/django/utils/importlib.py", line 35, in import_module
    **import**(name)
  File "/home/tony/work/qmag/django-testapp/djangoappengine/management/commands/runserver.py", line 5, in <module>
    from django.db import connections
  File "/home/tony/work/qmag/django-testapp/django/db/**init**.py", line 78, in <module>
    connection = connections[DEFAULT_DB_ALIAS]
  File "/home/tony/work/qmag/django-testapp/django/db/utils.py", line 94, in **getitem**
    conn = backend.DatabaseWrapper(db, alias)
  File "/home/tony/work/qmag/django-testapp/dbindexer/base.py", line 54, in DatabaseWrapper
    return Wrapper(merged_settings, _args, *_kwargs)
  File "/home/tony/work/qmag/django-testapp/dbindexer/base.py", line 37, in **init**
    super(BaseDatabaseWrapper, self).**init**(_args, *_kwargs)
  File "/home/tony/work/qmag/django-testapp/djangoappengine/db/base.py", line 290, in **init**
    self.ops = DatabaseOperations(self)
TypeError: **init**() takes exactly 1 argument (2 given)

```

The change in this PR seems to resolve it.
```
