### PR TITLE
Override the USE_TZ setting when running tests that use timezone naive ...

### DIFF
--- a/djangoappengine/tests/field_db_conversion.py
+++ b/djangoappengine/tests/field_db_conversion.py
@@ -1,6 +1,7 @@
 import datetime
 
 from django.test import TestCase
+from django.test.utils import override_settings
 
 from google.appengine.api.datastore import Get
 from google.appengine.api.datastore_types import Text, Category, Email, \
@@ -70,3 +71,5 @@ class FieldDBConversionTest(TestCase):
             if not isinstance(types, (list, tuple)):
                 types = (types, )
             self.assertTrue(type(getattr(model, name)) in types)
+
+FieldDBConversionTest = override_settings(USE_TZ=False)(FieldDBConversionTest)

--- a/djangoappengine/tests/field_options.py
+++ b/djangoappengine/tests/field_options.py
@@ -2,6 +2,7 @@ import datetime
 
 from django.test import TestCase
 from django.db.utils import DatabaseError
+from django.test.utils import override_settings
 from django.db.models.fields import NOT_PROVIDED
 
 from google.appengine.api import users
@@ -107,3 +108,5 @@ class FieldOptionsTest(TestCase):
 
         db_entity = NullableTextModel.objects.get()
         self.assertEquals(db_entity.text, None)
+
+FieldOptionsTest = override_settings(USE_TZ=False)(FieldOptionsTest)

--- a/djangoappengine/tests/filter.py
+++ b/djangoappengine/tests/filter.py
@@ -1,3 +1,5 @@
+from django.test.utils import override_settings
+
 import datetime
 import time
 
@@ -484,3 +486,5 @@ class FilterTest(TestCase):
         self.assertEqual(e['data'], x.data)
         x = BlobModel.objects.all()[0]
         self.assertEqual(e['data'], x.data)
+
+FilterTest = override_settings(USE_TZ=False)(FilterTest)


### PR DESCRIPTION
...datetimes
