### PR TITLE
Register search API stub in StubManager

### DIFF
--- a/djangoappengine/db/stubs.py
+++ b/djangoappengine/db/stubs.py
@@ -3,6 +3,8 @@ import os
 import time
 from urllib2 import HTTPError, URLError
 
+from google.appengine.api.search.simple_search_stub import SearchServiceStub
+
 from ..boot import PROJECT_DIR
 from ..utils import appid, have_appserver
 
@@ -65,6 +67,7 @@ class StubManager(object):
         self.testbed.init_user_stub()
         self.testbed.init_xmpp_stub()
         self.testbed.init_channel_stub()
+        self.testbed._register_stub("search", SearchServiceStub())
 
     def deactivate_test_stubs(self):
         if self.active_stubs == 'test':


### PR DESCRIPTION
Need to stub out the search API or local unit tests will run against the same index as the local dev server.
