### PR TITLE
Override the default deferred handler with a finite retry version.

### DIFF
--- a/djangoappengine/deferred/handler.py
+++ b/djangoappengine/deferred/handler.py
@@ -13,10 +13,54 @@ for app in settings.INSTALLED_APPS:
     except ImportError:
         pass
 
+# The maximum retry count on the original task queue. After that the task is reenqued on the broken-tasks queue
+MAX_RETRY_COUNT = getattr(settings, 'TASK_RETRY_ON_SOURCE_QUEUE', None)
+BROKEN_TASK_QUEUE = getattr(settings, 'BROKEN_TASK_QUEUE', 'broken-tasks')
 
-from google.appengine.ext.deferred.handler import main
-from google.appengine.ext.deferred.deferred import application
+import logging
+from google.appengine.api import taskqueue
+from google.appengine.ext.webapp import WSGIApplication
+from google.appengine.ext.webapp.util import run_wsgi_app
+from google.appengine.ext.deferred import deferred
 
 
-if __name__ == '__main__':
+class LimitedTaskHandler(deferred.TaskHandler):
+    def post(self):
+        try:
+            self.run_from_request()
+        except deferred.SingularTaskFailure:
+            logging.debug("Failure executing task, task retry forced")
+            self.response.set_status(408)
+
+        except deferred.PermanentTaskFailure:
+            logging.exception("Permanent failure attempting to execute task")
+
+        except Exception, exception:
+            logging.exception(exception)
+            retries = int(self.request.headers['X-AppEngine-TaskExecutioncount'])
+            already_broken = self.request.headers['X-AppEngine-Queuename'] == BROKEN_TASK_QUEUE
+
+            if already_broken or MAX_RETRY_COUNT is None or retries < MAX_RETRY_COUNT:
+                # Failing normally
+                self.error(500)
+            else:
+                logging.info("Retrying this task on the broken-tasks queue from now on")
+                # Reinserting task onto the brokentask queue
+                task = taskqueue.Task(
+                    payload=self.request.body,
+                    countdown=2.0,
+                    url=deferred._DEFAULT_URL,
+                    headers=deferred._TASKQUEUE_HEADERS
+                )
+                task.add(BROKEN_TASK_QUEUE)
+
+
+application = WSGIApplication([(".*", LimitedTaskHandler)])
+
+
+def main():
+    run_wsgi_app(application)
+
+
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
If a task fails because it happened to be pickled in a 'bad state' (an object pickled before schema changes for example) the only way to remove it from a task queue is to purge the whole queue.

This deferred handler will enqueue a task onto a `broken-tasks` (or `settings.BROKEN_TASK_QUEUE`) queue after it has failed after a certain amount of times. This only occurs if `settings.TASK_RETRY_ON_SOURCE_QUEUE = True`.
