### PR TITLE
Add support for devappserver2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ docs/_build
 .DS_Store
 
 MANIFEST
+dist/
+djangoappengine.egg-info/

--- a/djangoappengine/boot.py
+++ b/djangoappengine/boot.py
@@ -132,6 +132,15 @@ def setup_logging():
     # Fix Python 2.6 logging module.
     logging.logMultiprocessing = 0
 
+    # Set logging level to INFO when running in non-debug mode
+    from djangoappengine.utils import have_appserver
+    if have_appserver:
+        # We can't import settings at this point when running a normal
+        # manage.py command because this module gets imported from
+        # settings.py.
+        from django.conf import settings
+        if not settings.DEBUG:
+            logging.getLogger().setLevel(logging.INFO)
 
 def setup_project(dev_appserver_version):
     from djangoappengine.utils import have_appserver, on_production_server

--- a/djangoappengine/boot.py
+++ b/djangoappengine/boot.py
@@ -123,18 +123,6 @@ def setup_logging():
     # Fix Python 2.6 logging module.
     logging.logMultiprocessing = 0
 
-    # Enable logging.
-    level = logging.DEBUG
-    from .utils import have_appserver
-    if have_appserver:
-        # We can't import settings at this point when running a normal
-        # manage.py command because this module gets imported from
-        # settings.py.
-        from django.conf import settings
-        if not settings.DEBUG:
-            level = logging.INFO
-    logging.getLogger().setLevel(level)
-
 
 def setup_project():
     from .utils import have_appserver, on_production_server

--- a/djangoappengine/boot.py
+++ b/djangoappengine/boot.py
@@ -80,8 +80,8 @@ def setup_env(dev_appserver_version=1):
 
         if dev_appserver_version == 2:
             # emulate dev_appserver._run_file in devappserver2
-            from dev_appserver import _SYS_PATH_ADDITIONS
-            sys.path = _SYS_PATH_ADDITIONS['_python_runtime.py'] + sys.path
+            from dev_appserver import _PATHS
+            sys.path = _PATHS._script_to_paths['dev_appserver.py'] + sys.path
         fix_sys_path()
 
     setup_project(dev_appserver_version)

--- a/djangoappengine/db/base.py
+++ b/djangoappengine/db/base.py
@@ -342,7 +342,7 @@ class DatabaseWrapper(NonrelDatabaseWrapper):
             stub_manager.activate_test_stubs(self)
         else:
             destroy_datastore(get_datastore_paths(self.settings_dict))
-            stub_manager.setup_local_stubs(self)
+            stub_manager.reset_stubs(self)
 
 
 def delete_all_entities():

--- a/djangoappengine/db/base.py
+++ b/djangoappengine/db/base.py
@@ -158,7 +158,7 @@ class DatabaseOperations(NonrelDatabaseOperations):
                 value = key_from_path(field.model._meta.db_table, value)
             except (BadArgumentError, BadValueError,):
                 raise DatabaseError("Only strings and positive integers "
-                                    "may be used as keys on GAE.")
+                                    "may be used as keys on GAE. Received %r." % value)
 
         # Store all strings as unicode, use db.Text for longer content.
         elif db_type == 'string' or db_type == 'text':

--- a/djangoappengine/db/stubs.py
+++ b/djangoappengine/db/stubs.py
@@ -88,7 +88,7 @@ class StubManager(object):
             from google.appengine.tools import dev_appserver
         except ImportError:
             from google.appengine.tools import old_dev_appserver as dev_appserver
-        dev_appserver.SetupStubs('dev~' + appid, **args)
+        dev_appserver.SetupStubs(appid, **args)
         logging.getLogger().setLevel(log_level)
         self.active_stubs = 'local'
 

--- a/djangoappengine/db/stubs.py
+++ b/djangoappengine/db/stubs.py
@@ -88,7 +88,7 @@ class StubManager(object):
             from google.appengine.tools import dev_appserver
         except ImportError:
             from google.appengine.tools import old_dev_appserver as dev_appserver
-        dev_appserver.SetupStubs(appid, **args)
+        dev_appserver.SetupStubs('dev~' + appid, **args)
         logging.getLogger().setLevel(log_level)
         self.active_stubs = 'local'
 
@@ -96,8 +96,10 @@ class StubManager(object):
         if self.active_stubs == 'remote':
             return
         if not connection.remote_api_path:
-            from ..utils import appconfig
-            for handler in appconfig.handlers:
+            from djangoappengine.utils import appconfig
+            from google.appengine.api import appinfo
+            default_module = next(m for m in appconfig.modules if m.module_name == appinfo.DEFAULT_MODULE)
+            for handler in default_module.handlers:
                 if handler.script in REMOTE_API_SCRIPTS:
                     connection.remote_api_path = handler.url.split('(', 1)[0]
                     break

--- a/djangoappengine/management/commands/deploy.py
+++ b/djangoappengine/management/commands/deploy.py
@@ -29,8 +29,6 @@ def run_appcfg(argv):
 
     new_args = argv[:]
     new_args[1] = 'update'
-    if appconfig.runtime != 'python':
-        new_args.insert(1, '-R')
     new_args.append(PROJECT_DIR)
     syncdb = True
     if '--nosyncdb' in new_args:

--- a/djangoappengine/management/commands/runserver.py
+++ b/djangoappengine/management/commands/runserver.py
@@ -178,18 +178,12 @@ class Command(BaseRunserverCommand):
         for name in connections:
             connection = connections[name]
             if isinstance(connection, DatabaseWrapper):
-                for key, path in get_datastore_paths(
-                        connection.settings_dict).items():
-                    # XXX/TODO: Remove this when SDK 1.4.3 is released.
-                    if key == 'prospective_search_path':
-                        continue
-
+                for key, path in get_datastore_paths(connection.settings_dict).items():
                     arg = '--' + key
                     if arg not in args:
                         args.extend([arg, path])
                 # Get dev_appserver option presets, to be applied below.
-                preset_options = connection.settings_dict.get(
-                    'DEV_APPSERVER_OPTIONS', {})
+                preset_options = connection.settings_dict.get('DEV_APPSERVER_OPTIONS', {})
                 break
 
         # Process the rest of the options here.

--- a/djangoappengine/management/commands/runserver.py
+++ b/djangoappengine/management/commands/runserver.py
@@ -2,16 +2,28 @@ import logging
 from optparse import make_option
 import sys
 
-from django.db import connections
+from django.conf import settings
 from django.core.management.base import BaseCommand
-from django.core.management.commands.runserver import BaseRunserverCommand
+from django.core.management.commands.runserver import BaseRunserverCommand, DEFAULT_PORT
 from django.core.exceptions import ImproperlyConfigured
+from django.db import connections
 
-from google.appengine.tools import dev_appserver_main
+from djangoappengine.boot import PROJECT_DIR
+from djangoappengine.db.base import DatabaseWrapper, get_datastore_paths
 
-from ...boot import PROJECT_DIR
-from ...db.base import DatabaseWrapper, get_datastore_paths
+if settings.DEV_APPSERVER_VERSION == 1:
+    from google.appengine.tools import dev_appserver_main
+else:
+    import os
+    import _python_runtime
+    sys.argv[0] = os.path.join(
+                    os.path.dirname(_python_runtime.__file__),
+                    "devappserver2.py")
+    # The following import sets the path for _python_runtime.py from
+    # sys.argv[0], so we need to hack sys.argv[0] before this import
+    from google.appengine.tools.devappserver2 import devappserver2
 
+DEV_APPSERVER_V2_DEFAULT_PORT = "8080"
 
 class Command(BaseRunserverCommand):
     """
@@ -24,6 +36,10 @@ class Command(BaseRunserverCommand):
     """
 
     option_list = BaseCommand.option_list + (
+         make_option(
+            '--auto_id_policy',
+            help="Dictate how automatic IDs are assigned by the datastore " \
+                 "stub. 'sequential' or 'scattered'."),
         make_option(
             '--debug', action='store_true', default=False,
             help="Prints verbose debugging messages to the console while " \
@@ -106,7 +122,10 @@ class Command(BaseRunserverCommand):
         parse the arguments to this command.
         """
         # Hack __main__ so --help in dev_appserver_main works OK.
-        sys.modules['__main__'] = dev_appserver_main
+        if settings.DEV_APPSERVER_VERSION == 1:
+            sys.modules['__main__'] = dev_appserver_main
+        else:
+            sys.modules['__main__'] = devappserver2
         return super(Command, self).create_parser(prog_name, subcommand)
 
     def run_from_argv(self, argv):
@@ -130,9 +149,15 @@ class Command(BaseRunserverCommand):
         args = []
         # Set bind ip/port if specified.
         if self.addr:
-            args.extend(['--address', self.addr])
+            if settings.DEV_APPSERVER_VERSION == 1:
+                args.extend(['--address', self.addr])
+            else:
+                args.extend(['--host', self.addr])
         if self.port:
-            args.extend(['--port', self.port])
+            if settings.DEV_APPSERVER_VERSION == 1:
+                args.extend(['--port', self.port])
+            else:
+                args.extend(['--port', self.port if self.port != DEFAULT_PORT else DEV_APPSERVER_V2_DEFAULT_PORT])
 
         # If runserver is called using handle(), progname will not be
         # set.
@@ -140,7 +165,6 @@ class Command(BaseRunserverCommand):
             self.progname = 'manage.py'
 
         # Add email settings.
-        from django.conf import settings
         if not options.get('smtp_host', None) and \
            not options.get('enable_sendmail', None):
             args.extend(['--smtp_host', settings.EMAIL_HOST,
@@ -169,17 +193,22 @@ class Command(BaseRunserverCommand):
                 break
 
         # Process the rest of the options here.
-        bool_options = [
-            'debug', 'debug_imports', 'clear_datastore', 'require_indexes',
-            'high_replication', 'enable_sendmail', 'use_sqlite',
-            'allow_skipped_files', 'disable_task_running', ]
+        if settings.DEV_APPSERVER_VERSION == 1:
+            bool_options = [
+                'debug', 'debug_imports', 'clear_datastore', 'require_indexes',
+                'high_replication', 'enable_sendmail', 'use_sqlite',
+                'allow_skipped_files', 'disable_task_running']
+        else:
+            bool_options = [
+                'debug', 'debug_imports', 'clear_datastore', 'require_indexes',
+                'enable_sendmail', 'allow_skipped_files', 'disable_task_running']
         for opt in bool_options:
             if options[opt] != False:
-                args.append('--%s' % opt)
+                args.extend(['--%s' % opt, 'yes'])
 
         str_options = [
             'datastore_path', 'blobstore_path', 'history_path', 'login_url', 'smtp_host',
-            'smtp_port', 'smtp_user', 'smtp_password', ]
+            'smtp_port', 'smtp_user', 'smtp_password', 'auto_id_policy']
         for opt in str_options:
             if options.get(opt, None) != None:
                 args.extend(['--%s' % opt, options[opt]])
@@ -189,7 +218,7 @@ class Command(BaseRunserverCommand):
             arg = '--%s' % opt
             if arg not in args:
                 if value and opt in bool_options:
-                    args.append(arg)
+                    args.extend([arg, value])
                 elif opt in str_options:
                     args.extend([arg, value])
                 # TODO: Issue warning about bogus option key(s)?
@@ -199,4 +228,14 @@ class Command(BaseRunserverCommand):
         logging.getLogger().setLevel(logging.INFO)
 
         # Append the current working directory to the arguments.
-        dev_appserver_main.main([self.progname] + args + [PROJECT_DIR])
+        if settings.DEV_APPSERVER_VERSION == 1:
+            dev_appserver_main.main([self.progname] + args + [PROJECT_DIR])
+        else:
+            from google.appengine.api import apiproxy_stub_map
+
+            # Environment is set in djangoappengine.stubs.setup_local_stubs()
+            # We need to do this effectively reset the stubs.
+            apiproxy_stub_map.apiproxy = apiproxy_stub_map.GetDefaultAPIProxy()
+
+            sys.argv = ['/home/user/google_appengine/devappserver2.py'] + args + [PROJECT_DIR]
+            devappserver2.main()

--- a/djangoappengine/management/commands/runserver.py
+++ b/djangoappengine/management/commands/runserver.py
@@ -204,7 +204,10 @@ class Command(BaseRunserverCommand):
                 'enable_sendmail', 'allow_skipped_files', 'disable_task_running']
         for opt in bool_options:
             if options[opt] != False:
-                args.extend(['--%s' % opt, 'yes'])
+                if settings.DEV_APPSERVER_VERSION == 1:
+                    args.append('--%s' % opt)
+                else:
+                    args.extend(['--%s' % opt, 'yes'])
 
         str_options = [
             'datastore_path', 'blobstore_path', 'history_path', 'login_url', 'smtp_host',
@@ -218,7 +221,10 @@ class Command(BaseRunserverCommand):
             arg = '--%s' % opt
             if arg not in args:
                 if value and opt in bool_options:
-                    args.extend([arg, value])
+                    if settings.DEV_APPSERVER_VERSION == 1:
+                        args.append(arg)
+                    else:
+                        args.extend([arg, value])
                 elif opt in str_options:
                     args.extend([arg, value])
                 # TODO: Issue warning about bogus option key(s)?

--- a/djangoappengine/management/commands/testserver.py
+++ b/djangoappengine/management/commands/testserver.py
@@ -1,12 +1,14 @@
 from django.core.management.base import BaseCommand
 
+from djangoappengine.management.commands.runserver import Command as RunServerCommand
+
 from google.appengine.api import apiproxy_stub_map
 from google.appengine.datastore import datastore_stub_util
 
 from optparse import make_option
 
 class Command(BaseCommand):
-    option_list = BaseCommand.option_list + (
+    option_list = RunServerCommand.option_list + (
         make_option('--noinput', action='store_false', dest='interactive', default=True,
             help='Tells Django to NOT prompt the user for input of any kind.'),
         make_option('--addrport', action='store', dest='addrport',
@@ -27,8 +29,6 @@ class Command(BaseCommand):
         from ...db.stubs import stub_manager
 
         verbosity = int(options.get('verbosity'))
-        interactive = options.get('interactive')
-        addrport = options.get('addrport')
 
         db_name = None
 
@@ -63,4 +63,4 @@ class Command(BaseCommand):
         # a strange error -- it causes this handle() method to be called
         # multiple times.
         shutdown_message = '\nServer stopped.\nNote that the test database, %r, has not been deleted. You can explore it on your own.' % db_name
-        call_command('runserver', addrport=addrport, shutdown_message=shutdown_message, use_reloader=False, use_ipv6=options['use_ipv6'])
+        call_command('runserver', shutdown_message=shutdown_message, use_reloader=False, **options)

--- a/djangoappengine/management/commands/testserver.py
+++ b/djangoappengine/management/commands/testserver.py
@@ -25,7 +25,7 @@ class Command(BaseCommand):
     def handle(self, *fixture_labels, **options):
         from django.core.management import call_command
         from django import db
-        from ...db.base import get_datastore_paths, DatabaseWrapper
+        from ...db.base import get_datastore_paths, destroy_datastore, DatabaseWrapper
         from ...db.stubs import stub_manager
 
         verbosity = int(options.get('verbosity'))
@@ -38,11 +38,9 @@ class Command(BaseCommand):
                 settings = conn.settings_dict
                 for key, path in get_datastore_paths(settings).items():
                     settings[key] = "%s-testdb" % path
-                conn.flush()
+                destroy_datastore(get_datastore_paths(settings))
 
-                # reset stub manager
-                stub_manager.active_stubs = None
-                stub_manager.setup_local_stubs(conn)
+                stub_manager.reset_stubs(conn, datastore_path=settings['datastore_path'])
 
                 db_name = name
                 break

--- a/djangoappengine/settings_base.py
+++ b/djangoappengine/settings_base.py
@@ -1,9 +1,14 @@
+try:
+    from dev_appserver_version import DEV_APPSERVER_VERSION
+except ImportError:
+    DEV_APPSERVER_VERSION = 2
+
 # Initialize App Engine SDK if necessary.
 try:
     from google.appengine.api import apiproxy_stub_map
 except ImportError:
-    from .boot import setup_env
-    setup_env()
+    from djangoappengine.boot import setup_env
+    setup_env(DEV_APPSERVER_VERSION)
 
 from djangoappengine.utils import on_production_server, have_appserver
 

--- a/djangoappengine/utils.py
+++ b/djangoappengine/utils.py
@@ -3,22 +3,16 @@ import os
 from google.appengine.api import apiproxy_stub_map
 from google.appengine.api.app_identity import get_application_id
 
-
 have_appserver = bool(apiproxy_stub_map.apiproxy.GetStub('datastore_v3'))
 
 if have_appserver:
     appid = get_application_id()
 else:
     try:
-        try:
-            from google.appengine.tools import dev_appserver
-        except ImportError:
-            from google.appengine.tools import old_dev_appserver as dev_appserver
-
-        from .boot import PROJECT_DIR
-        appconfig = dev_appserver.LoadAppConfig(PROJECT_DIR, {},
-                                                default_partition='dev')[0]
-        appid = appconfig.application.split('~', 1)[-1]
+        from google.appengine.tools.devappserver2 import application_configuration
+        from djangoappengine.boot import PROJECT_DIR
+        appconfig = application_configuration.ApplicationConfiguration([PROJECT_DIR])
+        appid = appconfig.app_id
     except ImportError, e:
         raise Exception("Could not get appid. Is your app.yaml file missing? "
                         "Error was: %s" % e)

--- a/djangoappengine/utils.py
+++ b/djangoappengine/utils.py
@@ -12,7 +12,7 @@ else:
         from google.appengine.tools.devappserver2 import application_configuration
         from djangoappengine.boot import PROJECT_DIR
         appconfig = application_configuration.ApplicationConfiguration([PROJECT_DIR])
-        appid = appconfig.app_id
+        appid = appconfig.app_id.replace('dev~', '')
     except ImportError, e:
         raise Exception("Could not get appid. Is your app.yaml file missing? "
                         "Error was: %s" % e)


### PR DESCRIPTION
The old devappserver is still supported. To use it, add a file `dev_appserver_version.py` to your root project directory, it must contain the string `DEV_APPSERVER_VERSION = 1`.
