### PR TITLE
Add support for Google Cloud Storage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ install:
   - pip install git+http://github.com/django-nonrel/djangotoolbox@master\#egg=djangotoolbox --target=$PWD
   - pip install git+http://github.com/django-nonrel/django-dbindexer@master\#egg=django-dbindexer --target=$PWD
   - pip install git+https://github.com/adieu/django-autoload\#egg=django-autoload --target=$PWD
+  - pip install Pillow
 
 before_script:
   - wget https://storage.googleapis.com/appengine-sdks/featured/google_appengine_$APPENGINE_SDK_VERSION.zip -nv

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ install:
   - pip install git+http://github.com/django-nonrel/django-dbindexer@master\#egg=django-dbindexer --target=$PWD
   - pip install git+https://github.com/adieu/django-autoload\#egg=django-autoload --target=$PWD
   - pip install Pillow
+  - pip install GoogleAppEngineCloudStorageClient
 
 before_script:
   - wget https://storage.googleapis.com/appengine-sdks/featured/google_appengine_$APPENGINE_SDK_VERSION.zip -nv

--- a/djangoappengine/db/stubs.py
+++ b/djangoappengine/db/stubs.py
@@ -88,6 +88,9 @@ class StubManager(object):
         self.testbed.init_user_stub()
         self.testbed.init_xmpp_stub()
         self.testbed.init_channel_stub()
+        self.testbed.init_app_identity_stub()
+        self.testbed.init_blobstore_stub()
+        self.testbed.init_files_stub()
 
     def deactivate_test_stubs(self):
         if self.active_stubs == 'test':

--- a/djangoappengine/db/stubs.py
+++ b/djangoappengine/db/stubs.py
@@ -91,6 +91,7 @@ class StubManager(object):
         self.testbed.init_app_identity_stub()
         self.testbed.init_blobstore_stub()
         self.testbed.init_files_stub()
+        self.testbed.init_images_stub()
 
     def deactivate_test_stubs(self):
         if self.active_stubs == 'test':

--- a/djangoappengine/storage.py
+++ b/djangoappengine/storage.py
@@ -1,5 +1,6 @@
+import datetime
+import email
 import mimetypes
-import os
 import urlparse
 
 try:
@@ -8,24 +9,46 @@ except ImportError:
     from StringIO import StringIO
 
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 from django.core.files.base import File
 from django.core.files.storage import Storage
 from django.core.files.uploadedfile import UploadedFile
 from django.core.files.uploadhandler import FileUploadHandler, \
     StopFutureHandlers
-from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpResponse
 from django.utils.encoding import smart_str, force_unicode, filepath_to_uri
+
+try:
+    import cloudstorage
+except ImportError:
+    cloudstorage = None
 
 from google.appengine.api import files
 from google.appengine.api.images import get_serving_url, NotImageError, \
     TransformationError, BlobKeyRequiredError
 from google.appengine.ext.blobstore import BlobInfo, BlobKey, delete, \
-    create_upload_url, BLOB_KEY_HEADER, BLOB_RANGE_HEADER, BlobReader
+    create_upload_url, BLOB_KEY_HEADER, BLOB_RANGE_HEADER, BlobReader, \
+    create_gs_key, CLOUD_STORAGE_OBJECT_HEADER
 
+APPENGINE_STORAGE_SERVICE_KEY = 'APPENGINE_STORAGE_SERVICE'
+CLOUD_STORAGE_DEFAULT_BUCKET_KEY = 'CLOUD_STORAGE_DEFAULT_BUCKET'
 
-def prepare_upload(request, url, **kwargs):
-    return create_upload_url(url), {}
+BLOBSTORE_SERVICE = 'blobstore'
+CLOUD_STORAGE_SERVICE = 'gs'
+
+def prepare_upload(request, url, storage_service=None, cloud_storage_bucket=None, **kwargs):
+    if not storage_service:
+        storage_service = getattr(settings, APPENGINE_STORAGE_SERVICE_KEY, BLOBSTORE_SERVICE)
+
+    upload_kwargs = {}
+    if storage_service == 'gs':
+        if not cloud_storage_bucket:
+            cloud_storage_bucket = getattr(settings, CLOUD_STORAGE_DEFAULT_BUCKET_KEY, None)
+        if not cloud_storage_bucket:
+            raise ImproperlyConfigured("'cloud_storage_bucket' keyword argument or "
+                "settings.CLOUD_STORAGE_DEFAULT_BUCKET must be set when using Google Cloud Storage.")
+        upload_kwargs['gs_bucket_name'] = cloud_storage_bucket
+    return create_upload_url(url, **upload_kwargs), {}
 
 
 def serve_file(request, file, save_as, content_type, **kwargs):
@@ -35,7 +58,7 @@ def serve_file(request, file, save_as, content_type, **kwargs):
         blobkey = file.blobstore_info.key()
     else:
         raise ValueError("The provided file can't be served via the "
-                         "Google App Engine Blobstore.")
+                         "App Engine Blobstore or Google Cloud Storage.")
     response = HttpResponse(content_type=content_type)
     response[BLOB_KEY_HEADER] = str(blobkey)
     response['Accept-Ranges'] = 'bytes'
@@ -50,63 +73,106 @@ def serve_file(request, file, save_as, content_type, **kwargs):
     return response
 
 
-class BlobstoreStorage(Storage):
-    """Google App Engine Blobstore storage backend."""
+class AppEngineStorage(Storage):
+    """
+    Google App Engine storage backend.
+    Supports Blobstore and Cloud Storage.
+    """
+    def __init__(self, storage_service=None, cloud_storage_bucket=None):
+        super(AppEngineStorage, self).__init__()
+        if not storage_service:
+            storage_service = getattr(settings, APPENGINE_STORAGE_SERVICE_KEY, BLOBSTORE_SERVICE)
+        if not cloud_storage_bucket:
+            cloud_storage_bucket = getattr(settings, CLOUD_STORAGE_DEFAULT_BUCKET_KEY, None)
+
+        if storage_service not in (BLOBSTORE_SERVICE, CLOUD_STORAGE_SERVICE):
+            raise ImproperlyConfigured("APPENGINE_STORAGE_SERVICE must be either "
+                "'gs' or 'blobstore', not %s." % storage_service)
+        if storage_service == CLOUD_STORAGE_SERVICE and not cloud_storage_bucket:
+            raise ImproperlyConfigured("CLOUD_STORAGE_DEFAULT_BUCKET must be set "
+                "when using Google Cloud Storage.")
+
+        self.storage_service = storage_service
+        self.cloud_storage_bucket = cloud_storage_bucket
 
     def _open(self, name, mode='rb'):
-        return BlobstoreFile(name, mode, self)
+        return AppEngineFile(name, mode, self)
 
     def _save(self, name, content):
         name = name.replace('\\', '/')
-        if hasattr(content, 'file') and \
-           hasattr(content.file, 'blobstore_info'):
-            data = content.file.blobstore_info
-        elif hasattr(content, 'blobstore_info'):
+
+        if isinstance(content, (AppEngineFile, AppEngineUploadedFile)):
             data = content.blobstore_info
+        elif hasattr(content, 'file') and \
+             isinstance(content.file, (AppEngineFile, AppEngineUploadedFile)):
+            data = content.file.blobstore_info
         elif isinstance(content, File):
             guessed_type = mimetypes.guess_type(name)[0]
-            file_name = files.blobstore.create(mime_type=guessed_type or 'application/octet-stream',
-                                               _blobinfo_uploaded_filename=name)
 
-            with files.open(file_name, 'a') as f:
-                for chunk in content.chunks():
-                    f.write(chunk)
+            if self.storage_service == CLOUD_STORAGE_SERVICE:
+                assert cloudstorage, 'cloudstorage module is not available.'
 
-            files.finalize(file_name)
+                file_name = '/%s/%s' % (self.cloud_storage_bucket, name)
 
-            data = files.blobstore.get_blob_key(file_name)
+                with cloudstorage.open(file_name, 'w', guessed_type or 'application/octet-stream') as f:
+                    for chunk in content.chunks():
+                        f.write(chunk)
+
+                data = self._get_info('/gs' + file_name)
+            else:
+                # TODO deprecated
+
+                file_name = files.blobstore.create(mime_type=guessed_type or 'application/octet-stream',
+                                                   _blobinfo_uploaded_filename=name)
+
+                with files.open(file_name, 'a') as f:
+                    for chunk in content.chunks():
+                        f.write(chunk)
+
+                files.finalize(file_name)
+
+                data = files.blobstore.get_blob_key(file_name)
         else:
             raise ValueError("The App Engine storage backend only supports "
-                             "BlobstoreFile instances or File instances.")
+                             "AppEngineFile instances or File instances.")
 
-        if isinstance(data, (BlobInfo, BlobKey)):
-            # We change the file name to the BlobKey's str() value.
-            if isinstance(data, BlobInfo):
-                data = data.key()
+        if isinstance(data, CloudStorageInfo):
+            return '/gs' + data.fullname
+
+        if isinstance(data, BlobInfo):
+            data = data.key()
+
+        if isinstance(data, BlobKey):
             return '%s/%s' % (data, name.lstrip('/'))
-        else:
-            raise ValueError("The App Engine Blobstore only supports "
-                             "BlobInfo values. Data can't be uploaded "
-                             "directly. You have to use the file upload "
-                             "handler.")
+
+        raise ValueError("Unknown type returned from saving: %s" % type(data))
 
     def delete(self, name):
-        delete(self._get_key(name))
+        self._get_info(name).delete()
 
     def exists(self, name):
-        return self._get_blobinfo(name) is not None
+        info = self._get_info(name)
+        return info is not None and (not hasattr(info, 'exists') or info.exists())
 
     def size(self, name):
-        return self._get_blobinfo(name).size
+        return self._get_info(name).size
 
     def url(self, name):
         try:
-            return get_serving_url(self._get_blobinfo(name))
+            info = self._get_info(name)
+            if not info:
+                raise BlobKeyRequiredError('No blob info found for %s.' % name)
+            return get_serving_url(info.key())
         except (NotImageError, TransformationError):
             return None
+        except BlobKeyRequiredError:
+            if settings.DEBUG:
+                return urlparse.urljoin(settings.MEDIA_URL, filepath_to_uri(name))
+            else:
+                raise
 
     def created_time(self, name):
-        return self._get_blobinfo(name).creation
+        return self._get_info(name).creation
 
     def get_valid_name(self, name):
         return force_unicode(name).strip().replace('\\', '/')
@@ -114,26 +180,51 @@ class BlobstoreStorage(Storage):
     def get_available_name(self, name):
         return name.replace('\\', '/')
 
-    def _get_key(self, name):
-        return BlobKey(name.split('/', 1)[0])
+    def _get_info(self, name):
+        if name.startswith('/gs/'):
+            assert cloudstorage, 'cloudstorage module is not available.'
+            return CloudStorageInfo(name)
+        else:
+            key = BlobKey(name.split('/', 1)[0])
+            return BlobInfo.get(key)
 
-    def _get_blobinfo(self, name):
-        return BlobInfo.get(self._get_key(name))
 
-class DevBlobstoreStorage(BlobstoreStorage):
-    def url(self, name):
+class CloudStorageInfo(object):
+    def __init__(self, name):
+        self.fullname = name[3:]
+        self.filename = self.fullname.split('/', 2)[2]
+
+    def delete(self):
+        cloudstorage.delete(self.fullname)
+
+    def exists(self):
         try:
-            return super(DevBlobstoreStorage, self).url(name)
-        except BlobKeyRequiredError:
-            return urlparse.urljoin(settings.MEDIA_URL, filepath_to_uri(name))
+            cloudstorage.stat(self.fullname)
+            return True
+        except cloudstorage.NotFoundError:
+            return False
 
-class BlobstoreFile(File):
+    def key(self):
+        return create_gs_key('/gs' + self.fullname)
 
+    def open(self):
+        return cloudstorage.open(self.fullname, 'r')
+
+    @property
+    def creation(self):
+        return datetime.datetime.fromtimestamp(cloudstorage.stat(self.fullname).st_ctime)
+
+    @property
+    def size(self):
+        return cloudstorage.stat(self.fullname).st_size
+
+
+class AppEngineFile(File):
     def __init__(self, name, mode, storage):
         self.name = name
         self._storage = storage
         self._mode = mode
-        self.blobstore_info = storage._get_blobinfo(name)
+        self.blobstore_info = storage._get_info(name)
 
     @property
     def size(self):
@@ -145,52 +236,81 @@ class BlobstoreFile(File):
     @property
     def file(self):
         if not hasattr(self, '_file'):
-            self._file = BlobReader(self.blobstore_info.key())
+            self._file = self.blobstore_info.open()
         return self._file
 
-
-class BlobstoreFileUploadHandler(FileUploadHandler):
+class AppEngineFileUploadHandler(FileUploadHandler):
     """
-    File upload handler for the Google App Engine Blobstore.
+    File upload handler for Google App Engine. Supports both
+    Blobstore and Google Cloud Storage
     """
 
     def new_file(self, *args, **kwargs):
         super(BlobstoreFileUploadHandler, self).new_file(*args, **kwargs)
         blobkey = self.content_type_extra.get('blob-key')
-        self.active = blobkey is not None
-        if self.active:
+        self.activated = blobkey is not None
+        if self.activated:
             self.blobkey = BlobKey(blobkey)
+            self.filename = kwargs.get('file_name', None)
+            self.file = StringIO()
             raise StopFutureHandlers()
 
     def receive_data_chunk(self, raw_data, start):
         """
         Add the data to the StringIO file.
         """
-        if not self.active:
+        if self.activated:
+            self.file.write(raw_data)
+        else:
             return raw_data
 
     def file_complete(self, file_size):
         """
         Return a file object if we're activated.
         """
-        if not self.active:
+        if not self.activated:
             return
 
-        return BlobstoreUploadedFile(
-            blobinfo=BlobInfo(self.blobkey),
-            charset=self.charset)
+        self.file.seek(0)
+        upload_content = email.message_from_file(self.file)
+
+        def get_value(dict, name):
+            value = dict.get(name, None)
+            if value is None:
+                raise Exception('Missing field %s.' % (field_name, name))
+            return value
+
+        content_type = get_value(upload_content, 'content-type')
+        size = get_value(upload_content, 'content-length')
+        gs_object_name = upload_content.get(CLOUD_STORAGE_OBJECT_HEADER, None)
+
+        kwargs = {
+            'blob_key': self.blobkey,
+            'name': self.file_name,
+            'content_type': content_type,
+            'size': int(size),
+            'charset': self.charset,
+        }
+
+        return AppEngineUploadedFile(**kwargs)
 
 
-class BlobstoreUploadedFile(UploadedFile):
+class AppEngineUploadedFile(UploadedFile):
     """
-    A file uploaded into memory (i.e. stream-to-memory).
+    A file uploaded via App Engine's upload mechanism.
     """
 
-    def __init__(self, blobinfo, charset):
-        super(BlobstoreUploadedFile, self).__init__(
-            BlobReader(blobinfo.key()), blobinfo.filename,
-            blobinfo.content_type, blobinfo.size, charset)
-        self.blobstore_info = blobinfo
+    def __init__(self, **kwargs):
+        gs_object_name = kwargs.pop('gs_object_name', None)
+        blob_key = kwargs.pop('blob_key', None)
+        if gs_object_name:
+            self.blobstore_info = CloudStorageInfo(gs_object_name)
+        elif blob_key:
+            self.blobstore_info = BlobInfo(blob_key)
+        else:
+            raise ValueError('A gs_object_name or blob_key is required.')
+
+        super(AppEngineUploadedFile, self).__init__(self.blobstore_info.open(), **kwargs)
 
     def open(self, mode=None):
         pass
@@ -205,3 +325,10 @@ class BlobstoreUploadedFile(UploadedFile):
 
     def multiple_chunks(self, chunk_size=1024 * 128):
         return True
+
+# Backwards compatibility
+BlobstoreStorage = AppEngineStorage
+DevBlobstoreStorage = AppEngineStorage
+BlobstoreFile = AppEngineFile
+BlobstoreFileUploadHandler = AppEngineFileUploadHandler
+BlobstoreUploadedFile = AppEngineUploadedFile

--- a/djangoappengine/storage.py
+++ b/djangoappengine/storage.py
@@ -246,7 +246,7 @@ class AppEngineFileUploadHandler(FileUploadHandler):
     """
 
     def new_file(self, *args, **kwargs):
-        super(BlobstoreFileUploadHandler, self).new_file(*args, **kwargs)
+        super(AppEngineFileUploadHandler, self).new_file(*args, **kwargs)
         blobkey = self.content_type_extra.get('blob-key')
         self.activated = blobkey is not None
         if self.activated:

--- a/djangoappengine/tests/__init__.py
+++ b/djangoappengine/tests/__init__.py
@@ -7,3 +7,4 @@ from .test_mapreduce import DjangoModelInputReaderTest, DjangoModelIteratorTest
 from .test_not_return_sets import NonReturnSetsTest
 from .test_order import OrderTest
 from .test_transactions import TransactionTest
+from .test_storage import BlobstoreStorageTest, GSStorageTest

--- a/djangoappengine/tests/test_storage.py
+++ b/djangoappengine/tests/test_storage.py
@@ -1,0 +1,113 @@
+try:
+    import cloudstorage
+except ImportError:
+    cloudstorage = None
+
+from django.core.files.base import ContentFile
+from django.test import TestCase
+from django.test.utils import override_settings
+from django.utils import unittest
+
+from djangoappengine.storage import AppEngineStorage, CloudStorageInfo, BLOBSTORE_SERVICE, CLOUD_STORAGE_SERVICE
+
+from google.appengine.api import files
+from google.appengine.ext.blobstore import BlobInfo, BlobKey
+
+
+class AppEngineStorageBaseTest(object):
+    def test_file_accessed_time(self):
+        self.assertRaises(NotImplementedError, self.storage.accessed_time, self.file_key)
+
+    def test_file_created_time(self):
+        ctime = self.storage.created_time(self.file_key)
+
+        self.assertEqual(ctime, self.test_file_info.creation)
+
+    def test_file_modified_time(self):
+        self.assertRaises(NotImplementedError, self.storage.modified_time, self.file_key)
+
+    def test_file_exists(self):
+        self.assertTrue(self.storage.exists(self.file_key))
+
+    def test_file_does_not_exist(self):
+        self.assertFalse(self.storage.exists('abcdef'))
+
+    def test_listdir(self):
+        self.assertRaises(NotImplementedError, self.storage.listdir, '')
+
+    def test_file_save_without_name(self):
+        f = ContentFile('custom contents')
+        f.name = 'test.file'
+
+        storage_f_name = self.storage.save(None, f)
+
+        info = self.file_info(storage_f_name)
+
+        self.assertEqual(info.filename, f.name)
+
+    def test_file_save_with_path(self):
+        path = 'path/to/test.file'
+
+        storage_f_name = self.storage.save(path,
+                             ContentFile('file saved with path'))
+
+        self.assertTrue(self.storage.exists(storage_f_name))
+        self.assertEqual(self.storage.open(storage_f_name).read(),
+            'file saved with path')
+
+        info = self.file_info(storage_f_name)
+
+        self.assertEqual(info.filename, path)
+
+    def test_file_path(self):
+        f = ContentFile('custom contents')
+        f_name = self.storage.save('test.file', f)
+
+        self.assertRaises(NotImplementedError, self.storage.path, f_name)
+
+
+class BlobstoreStorageTest(AppEngineStorageBaseTest, TestCase):
+    def setUp(self):
+        super(BlobstoreStorageTest, self).setUp()
+
+        self.storage = AppEngineStorage(storage_service=BLOBSTORE_SERVICE)
+
+        file_name = files.blobstore.create()
+
+        with files.open(file_name, 'a') as f:
+            f.write('abcdef')
+
+        files.finalize(file_name)
+
+        self.blob_key = files.blobstore.get_blob_key(file_name)
+        self.file_key = str(self.blob_key)
+        self.test_file_info = self.file_info(self.file_key)
+
+    def file_info(self, name):
+        key = BlobKey(name.split('/', 1)[0])
+        return BlobInfo(key)
+
+    def test_file_url(self):
+        url = self.storage.url(self.file_key)
+        self.assertEqual(url, 'http://localhost:8080/_ah/img/%s' % self.file_key)
+
+@unittest.skipUnless(cloudstorage, 'cloudstorage not installed')
+class GSStorageTest(AppEngineStorageBaseTest, TestCase):
+    def setUp(self):
+        super(GSStorageTest, self).setUp()
+
+        self.storage = AppEngineStorage(storage_service=CLOUD_STORAGE_SERVICE, cloud_storage_bucket='test_bucket')
+
+        file_name = '/test_bucket/file.test'
+        with cloudstorage.open(file_name, 'w') as f:
+            f.write('abcdef')
+
+        self.file_key = '/gs' + file_name
+        self.test_file_info = self.file_info(self.file_key)
+
+    def file_info(self, name):
+        return CloudStorageInfo(name)
+
+    def test_file_url(self):
+        url = self.storage.url(self.file_key)
+        self.assertTrue(url.startswith('http://localhost:8080/_ah/img/encoded_gs_file:'))

--- a/djangoappengine/tests/test_storage.py
+++ b/djangoappengine/tests/test_storage.py
@@ -89,7 +89,7 @@ class BlobstoreStorageTest(AppEngineStorageBaseTest, TestCase):
 
     def test_file_url(self):
         url = self.storage.url(self.file_key)
-        self.assertEqual(url, 'http://localhost:8080/_ah/img/%s' % self.file_key)
+        self.assertEqual(url, '/_ah/img/%s' % self.file_key)
 
 @unittest.skipUnless(cloudstorage, 'cloudstorage not installed')
 class GSStorageTest(AppEngineStorageBaseTest, TestCase):
@@ -110,4 +110,4 @@ class GSStorageTest(AppEngineStorageBaseTest, TestCase):
 
     def test_file_url(self):
         url = self.storage.url(self.file_key)
-        self.assertTrue(url.startswith('http://localhost:8080/_ah/img/encoded_gs_file:'))
+        self.assertTrue(url.startswith('/_ah/img/encoded_gs_file:'))


### PR DESCRIPTION
By adding some `settings.py` configuration, the `AppEngineStorage` service can read and write to Google Cloud Storage.

``` python
APPENGINE_STORAGE_SERVICE = 'gs'
CLOUD_STORAGE_DEFAULT_BUCKET = '<bucket name goes here>'
```
