### PR TITLE
Add query filter support for map-reduce

### DIFF
--- a/djangoappengine/mapreduce/input_readers.py
+++ b/djangoappengine/mapreduce/input_readers.py
@@ -30,6 +30,10 @@ class DjangoModelIterator(AbstractKeyRangeIterator):
             else:
                 q = q.filter(pk__lt=k_range.key_end.id_or_name())
 
+        filters = self._query_spec.filters
+        if filters:
+            q = q.filter(**dict([[filter[0], filter[2]] for filter in filters]))
+
         q = q.order_by('pk')
 
         q = set_config(q, batch_size=self._query_spec.batch_size)


### PR DESCRIPTION
Example:

``` python
from djangoappengine.mapreduce import pipeline

class PipelineBase(base_handler.PipelineBase):

    def run(self):
        yield pipeline.DjangoModelMapreduce(models.Comment, mapper, reducer,
            extra_mapper_params = {
                'filters': [
                    ('user_id', '=', 123),
                    ('some_value__isnull', '=', True),
                ]
            }
        )
```
